### PR TITLE
add support for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Currently the only solution is to set the password of `login` keyring to empty. 
 
 I encrypt the `keyring-name : password` pair with GnuPG and save it as `secret-file`. Then on starting gnome, you have yubikey inserted. Then an auto-started script call GnuPG to decrypt the secret file, and pipe use the password to unlock your keyring. GnuPG will ask you to insert yubikey.
 
-## Usage
+## Dependencies
+The project uses libgnome-keyring-dev
 
-> I recommend you to **configure Yubikey as GPG smartcard**. The system would just ask you to unlock gnome-keyring with your default GPG software. You may generate a new GPG key for yubikey, or move your existing GPG key into yubikey. Refer to google for these knowledge. 
-
-First, install packages.
+### Ubuntu 20.04
+libgnome-keyring-dev is not in the repositories, you have to install it and its dependencies manually:
 ```
 wget http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.27-3ubuntu1_amd64.deb
 wget http://security.ubuntu.com/ubuntu/pool/universe/libg/libgnome-keyring/libgnome-keyring-common_3.12.0-1build1_all.deb
@@ -32,7 +32,11 @@ sudo dpkg-reconfigure multiarch-support
 sudo dpkg -i libgnome-keyring-common_3.12.0-1build1_all.deb libgnome-keyring0_3.12.0-1build1_amd64.deb gir1.2-gnomekeyring-1.0_3.12.0-1build1_amd64.deb libgnome-keyring-dev_3.12.0-1build1_amd64.deb
 ```
 
-Then, build the project from source.
+## Usage
+
+> I recommend you to **configure Yubikey as GPG smartcard**. The system would just ask you to unlock gnome-keyring with your default GPG software. You may generate a new GPG key for yubikey, or move your existing GPG key into yubikey. Refer to google for these knowledge. 
+
+First, build the project from source.
 ```
 git clone https://github.com/recolic/gnome-keyring-yubikey-unlock --recursive
 cd gnome-keyring-yubikey-unlock/src && make && cd ..

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ gnome-keyring-yubikey-unlock/create_secret_file.sh /path/to/your_secret [Your Gn
 # input your keyring:password
 ```
 
+As an example, I need to input `默认钥匙环:My_Very_Long_Login_Password`.
+
 Then, add the following command to gnome-autostart. You should know how to auto-run a command after starting gnome.
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,20 @@ I encrypt the `keyring-name : password` pair with GnuPG and save it as `secret-f
 
 > I recommend you to **configure Yubikey as GPG smartcard**. The system would just ask you to unlock gnome-keyring with your default GPG software. You may generate a new GPG key for yubikey, or move your existing GPG key into yubikey. Refer to google for these knowledge. 
 
-First, build the project from source.
+First, install packages.
+```
+wget http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.27-3ubuntu1_amd64.deb
+wget http://security.ubuntu.com/ubuntu/pool/universe/libg/libgnome-keyring/libgnome-keyring-common_3.12.0-1build1_all.deb
+wget http://security.ubuntu.com/ubuntu/pool/universe/libg/libgnome-keyring/libgnome-keyring0_3.12.0-1build1_amd64.deb
+wget http://security.ubuntu.com/ubuntu/pool/universe/libg/libgnome-keyring/gir1.2-gnomekeyring-1.0_3.12.0-1build1_amd64.deb
+wget http://security.ubuntu.com/ubuntu/pool/universe/libg/libgnome-keyring/libgnome-keyring-dev_3.12.0-1build1_amd64.deb
+
+sudo dpkg -i multiarch-support_2.27-3ubuntu1_amd64.deb
+sudo dpkg-reconfigure multiarch-support
+sudo dpkg -i libgnome-keyring-common_3.12.0-1build1_all.deb libgnome-keyring0_3.12.0-1build1_amd64.deb gir1.2-gnomekeyring-1.0_3.12.0-1build1_amd64.deb libgnome-keyring-dev_3.12.0-1build1_amd64.deb
+```
+
+Then, build the project from source.
 ```
 git clone https://github.com/recolic/gnome-keyring-yubikey-unlock --recursive
 cd gnome-keyring-yubikey-unlock/src && make && cd ..
@@ -30,8 +43,6 @@ Then, create your secret file.
 gnome-keyring-yubikey-unlock/create_secret_file.sh /path/to/your_secret [Your GnuPG public key]
 # input your keyring:password
 ```
-
-As an example, I need to input `默认钥匙环:My_Very_Long_Login_Password`.
 
 Then, add the following command to gnome-autostart. You should know how to auto-run a command after starting gnome.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,5 +6,5 @@ EXTRA_FLAGS ?=
 
 secret:
 	mkdir -p ../bin/
-	$(CXX) $(CXXFLAGS) $(EXTRA_FLAGS) unlock_keyrings.cc -o ../bin/unlock_keyrings
+	$(CXX)  unlock_keyrings.cc -o ../bin/unlock_keyrings $(CXXFLAGS) $(EXTRA_FLAGS)
 

--- a/tools/list_keyrings.sh
+++ b/tools/list_keyrings.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname $0)
+cd $(dirname $0) &&
 eval g++ list_keyrings.cc -o list.out -Wno-deprecated-declarations $(pkg-config --cflags --libs gnome-keyring-1) &&
 ./list.out
 

--- a/tools/list_keyrings.sh
+++ b/tools/list_keyrings.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-eval g++ $(pkg-config --cflags --libs gnome-keyring-1) list_keyrings.cc -o list.out &&
+cd $(dirname $0)
+eval g++ list_keyrings.cc -o list.out -Wno-deprecated-declarations $(pkg-config --cflags --libs gnome-keyring-1) &&
 ./list.out
 


### PR DESCRIPTION
I added the instructions and changes I needed to make to make the program runable on Ubuntu 20.04.

g++ seems to need the input-file and output-parameter before the includes are declared (why ever that is?!)
Ubuntu 20.04 does not have the needed packages in its repository so I added a section in README on how to install the dependencies.