### PR TITLE
Automatic pinentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Then, add the following command to gnome-autostart. You should know how to auto-
 /path/to/this/project/unlock_keyrings.sh /path/to/your_secret
 ```
 
+Optionally, if you don't want to enter your GPG smartcard pin every time you log in, add it as parameter to the command. If your pin is e.g. 123456:
+
+```
+/path/to/this/project/unlock_keyrings.sh /path/to/your_secret 123456
+```
+
+This obviously weakens the security of the private key, so obviously only do this if you're comfortable with having your pin stored on your disk in plain text.
+
 You're all set! Re-login and have a try!
 
 ## FAQ

--- a/unlock_keyrings.sh
+++ b/unlock_keyrings.sh
@@ -3,8 +3,9 @@
 
 _self_bin_name="$0"
 secret_file="$1"
+smartcard_pin="$2"
 
-[[ "$secret_file" = '' ]] && echo "Usage: $0 <secret_file>" && exit 1
+[[ "$secret_file" = '' ]] && echo "Usage: $0 <secret_file> [<smartcard pin>]" && exit 1
 
 function where_is_him () {
     SOURCE="$1"
@@ -22,8 +23,13 @@ function where_am_i () {
     [[ "$_my_path" = "" ]] && where_is_him "$_self_bin_name" || where_is_him "$_my_path"
 }
 
+gpg_options=()
+if [[ ! "$smartcard_pin" = '' ]]; then
+    gpg_options=("--pinentry-mode" "loopback" "--passphrase" "$smartcard_pin")
+fi
+
 cd `where_am_i` &&
-gpg --decrypt "$secret_file" | bin/unlock_keyrings --secret-file - --quiet
+gpg "${gpg_options[@]}" --decrypt "$secret_file" | bin/unlock_keyrings --secret-file - --quiet
 
 exit $?
 


### PR DESCRIPTION
This change allows users to log in without having to enter their GPG smartcard pin.

Currently, when logging in, in order to decrypt the secret file, you have to unlock the private key on the Yubikey with a six digit pin. GnuPG doesn't allow empty pins, and usually, at this point the gpg-agent only started and didn't store any passphrases yet.

This change allows users to log in without having to enter their pin again. I am aware that this weakens the security of the private key significantly, which is why I made that optional. You still need physical access to the Yubikey nevertheless, and if you don't use the PGP key for anything other than unlocking the gnome keychain, I believe that this risk is acceptable.

I made this change under the assumption that there is no way allowing gpg-agent to store passphrases across sessions. At least I wasn't able to find any in the ten minutes of searching I did. If there is one, please let me know.