### PR TITLE
Add documentation for systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ gnome-keyring-yubikey-unlock/create_secret_file.sh /path/to/your_secret [Your Gn
 
 As an example, I need to input `login:My_Very_Long_Login_Password`. (You may use `seahorse` or `tools/list_keyrings.sh` to determine the name of your keyring)
 
-Then, add the following command to gnome-autostart. You should know how to auto-run a command after starting gnome.
+Then, add the following command to gnome-autostart. If you don't know how to do it, [read me](doc/how-to-gnome-autostart.md)! 
 
 ```
 /path/to/this/project/unlock_keyrings.sh /path/to/your_secret

--- a/doc/how-to-gnome-autostart.md
+++ b/doc/how-to-gnome-autostart.md
@@ -1,0 +1,34 @@
+# How To Autostart On Gnome
+
+To automatically unlock keyrings right after logging into Gnome, you need to autostart
+`unlock_keyrings.sh`. There are different ways to to this.
+
+## Start Via Systemd
+
+Create a new file at `~/.config/systemd/user/unlock-keyring.service` with the following content
+(adapt the command after `ExecStart` to your setup):
+
+```ini
+[Unit]
+Description=Unlock keyring using YubiKey
+BindsTo=gnome-session.target
+
+[Service]
+Type=oneshot
+ExecStart=/path/to/this/project/unlock_keyrings.sh /path/to/your_secret 123456
+
+[Install]
+WantedBy=gnome-session.target
+```
+
+Run the following command (not root):
+
+```sh
+systemctl --user enable unlock-keyring.service
+```
+
+When doing changes to the service file, run
+
+```sh
+systemctl --user daemon-reload
+```


### PR DESCRIPTION
I was struggling to get the command started in a way that Gnome would not ask me to unlock my keychain right after login. Initially I tried to add an autostart entry using `gnome-session-properties` which had exactly this effect. I found that using a Systemd service solved this problem. So maybe we can save people some trouble by suggesting this right away.